### PR TITLE
Day2

### DIFF
--- a/internal/scoop/listen.go
+++ b/internal/scoop/listen.go
@@ -74,6 +74,11 @@ func (c *CMD) shutdown() {
 	if err := c.ln.Close(); err != nil {
 		c.Log.Println(err)
 	}
+
+	c.Log.Println("Saving datafile")
+	if err := c.store.unload(); err != nil {
+		c.Log.Println(err)
+	}
 }
 
 func (c *CMD) sendNOOP() error {

--- a/internal/scoop/parse.go
+++ b/internal/scoop/parse.go
@@ -26,5 +26,9 @@ func parse(m []string) (message, error) {
 	pkg := m[1]
 	dep := m[2]
 
-	return message{cmd, pkg, strings.Split(dep, ","), make(chan response)}, nil
+	deps := []string{}
+	if dep != "" {
+		deps = strings.Split(dep, ",")
+	}
+	return message{cmd, pkg, deps, make(chan response)}, nil
 }

--- a/internal/scoop/scoop.go
+++ b/internal/scoop/scoop.go
@@ -48,9 +48,17 @@ const (
 func New(port int, timeout time.Duration, dir string, verbose bool) *CMD {
 	log := log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC|log.Lshortfile)
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		log.Fatalf("ERROR: can't create %q: %v", dir, err)
+	t := time.Now().UTC()
+
+	store := &store{
+		PKGS:      make(map[string][]string),
+		DEPS:      make(map[string]map[string]bool),
+		CreatedAt: t,
+		dir:       dir,
+		messages:  make(chan message),
+		log:       log,
 	}
+	store.load()
 
 	c := &CMD{
 		Port:    port,
@@ -59,11 +67,7 @@ func New(port int, timeout time.Duration, dir string, verbose bool) *CMD {
 		done:    make(chan bool),
 		timeout: timeout,
 		verbose: verbose,
-		store: &store{
-			dir:      dir,
-			messages: make(chan message),
-			log:      log,
-		},
+		store:   store,
 	}
 	return c
 }

--- a/internal/scoop/serve.go
+++ b/internal/scoop/serve.go
@@ -43,11 +43,11 @@ func (c *CMD) serveWrk(r *bufio.Reader, w *bufio.Writer, addr string) error {
 	}
 	input = strings.TrimRight(input, "\n")
 
-	c.Log.Printf("serving %s: %q", addr, input)
+	c.Log.Printf("serving %s:%q", addr, input)
 	output, err := c.store.handle(input)
 	if err != nil {
 		// on error the output = ERROR and we want to propogate it to the client
-		c.Log.Printf("fail %s:%q -> %v", addr, input, err)
+		c.Log.Printf("err %s:%q -> %v", addr, input, err)
 	} else {
 		c.Log.Printf("done %s:%q -> %q", addr, input, output)
 	}

--- a/internal/scoop/store.go
+++ b/internal/scoop/store.go
@@ -1,19 +1,40 @@
 package scoop
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 type store struct {
+	// PKGS - installed pkgs and their dependencies
+	PKGS map[string][]string `json:"pkgs"`
+
+	// DEPS - reverse lookup of dependencies for a given pkg
+	// pkg1:{pkg2:true,pkg3:true,pkg4:true}
+	// which reads:
+	// 	pkgs 2,3,4 depend on pkg 1
+	DEPS map[string]map[string]bool `json:"deps"`
+
+	// CreatedAt - The time when the mapping was created (UTC)
+	CreatedAt time.Time `json:"createdAt"`
+
+	// UpdatedAt - The time when the mapping was updated last (UTC)
+	UpdatedAt time.Time `json:"updatedAt"`
+
 	dir      string
 	messages chan (message)
 	log      *log.Logger
 }
 
 const (
-	sep = "|"
+	sep       = "|"
+	storeName = "scoop.json"
 )
 
 // handle passes the input commands to the store worker
@@ -54,13 +75,103 @@ func (s *store) worker() {
 }
 
 func (s *store) index(msg message) {
+	for _, name := range msg.DEP {
+		if _, found := s.PKGS[name]; !found {
+			err := fmt.Errorf("%q's dependency %q is missing", msg.PKG, name)
+			msg.retChan <- response{FAIL, err}
+			return
+		}
+	}
+
+	s.PKGS[msg.PKG] = msg.DEP
+
+	for _, name := range msg.DEP {
+		if deps, found := s.DEPS[name]; found {
+			deps[msg.PKG] = true
+		} else {
+			s.DEPS[name] = map[string]bool{msg.PKG: true}
+		}
+	}
+
 	msg.retChan <- response{OK, nil}
 }
 
 func (s *store) remove(msg message) {
+	dependsOn, found := s.PKGS[msg.PKG]
+	if !found {
+		msg.retChan <- response{OK, nil}
+		return
+	}
+
+	if deps, found := s.DEPS[msg.PKG]; found {
+		err := fmt.Errorf("%q has active dependencies %v", msg.PKG, deps)
+		msg.retChan <- response{FAIL, err}
+		return
+	}
+
+	for _, name := range dependsOn {
+		deps, found := s.DEPS[name]
+		if found {
+			delete(deps, msg.PKG)
+			if len(deps) == 0 {
+				delete(s.DEPS, name)
+			}
+		}
+	}
+
+	delete(s.PKGS, msg.PKG)
+
 	msg.retChan <- response{OK, nil}
 }
 
 func (s *store) query(msg message) {
-	msg.retChan <- response{OK, nil}
+	if _, found := s.PKGS[msg.PKG]; found {
+		msg.retChan <- response{OK, nil}
+	} else {
+		msg.retChan <- response{FAIL, nil}
+	}
+}
+
+func (s *store) datafile() string {
+	path := fmt.Sprintf("%s/%s", s.dir, storeName)
+	return filepath.FromSlash(path)
+}
+
+// load gets called on startup so it's Ok to explode on failure
+// it loads the cached contents of store's datafile into memory
+func (s *store) load() {
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
+		log.Fatalf("ERROR: can't create %q: %v", s.dir, err)
+	}
+
+	datafile := s.datafile()
+
+	if _, err := os.Stat(datafile); os.IsNotExist(err) {
+		// store does not exist, exiting
+		return
+	}
+
+	content, err := ioutil.ReadFile(datafile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := json.Unmarshal(content, s); err != nil {
+		log.Fatalf("ERROR: can't unmarshal datafile %q: %v", datafile, err)
+	}
+
+	s.log.Printf("loaded %q datafile", datafile)
+}
+
+// unload saves the in-memory store to it's datafile
+func (s *store) unload() error {
+	s.UpdatedAt = time.Now().UTC()
+	b, err := json.MarshalIndent(s, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	datafile := s.datafile()
+	s.log.Printf("unloading %q datafile", datafile)
+	return ioutil.WriteFile(datafile, b, 0700)
 }


### PR DESCRIPTION
business logic fully implemented and test passed:

```
mve@box package_contents $ ./do-package-tree_darwin
2019/01/15 18:13:09 ================
2019/01/15 18:13:09  Starting test
2019/01/15 18:13:09 ================
2019/01/15 18:13:09 expected server port [8080]
2019/01/15 18:13:09 concurrency level    [10]
2019/01/15 18:13:09 unluckiness          [5]
2019/01/15 18:13:09 TESTRUN Starting...
2019/01/15 18:13:09 TESTRUN - Trying to remove, index, then remove again a large amount of packages
2019/01/15 18:13:09 Step 1: Attempting to remove any previously installed packages (by failed test runs or whatever other reason)
2019/01/15 18:13:09 Starting client[11]
2019/01/15 18:13:09 Starting client[3]
2019/01/15 18:13:09 Starting client[2]
2019/01/15 18:13:09 client[3] connecting to [localhost:8080]
2019/01/15 18:13:09 client[2] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[8]
2019/01/15 18:13:09 client[8] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[6]
2019/01/15 18:13:09 client[6] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[9]
2019/01/15 18:13:09 client[9] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[4]
2019/01/15 18:13:09 client[4] connecting to [localhost:8080]
2019/01/15 18:13:09 client[11] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[5]
2019/01/15 18:13:09 client[5] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[10]
2019/01/15 18:13:09 client[10] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[7]
2019/01/15 18:13:09 client[7] connecting to [localhost:8080]
2019/01/15 18:13:09 client[3] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[10] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[9] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[5] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[6] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[7] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[4] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[8] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[11] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[2] brute-forcing removal of 337 packages
2019/01/15 18:13:09 client[4] reports 0/337 packages still installed
2019/01/15 18:13:09 client[4] disconnecting
2019/01/15 18:13:09 client[5] reports 0/337 packages still installed
2019/01/15 18:13:09 client[5] disconnecting
2019/01/15 18:13:09 client[7] reports 0/337 packages still installed
2019/01/15 18:13:09 client[7] disconnecting
2019/01/15 18:13:09 client[10] reports 0/337 packages still installed
2019/01/15 18:13:09 client[10] disconnecting
2019/01/15 18:13:09 client[11] reports 0/337 packages still installed
2019/01/15 18:13:09 client[11] disconnecting
2019/01/15 18:13:09 client[9] reports 0/337 packages still installed
2019/01/15 18:13:09 client[9] disconnecting
2019/01/15 18:13:09 client[2] reports 0/337 packages still installed
2019/01/15 18:13:09 client[2] disconnecting
2019/01/15 18:13:09 client[8] reports 0/337 packages still installed
2019/01/15 18:13:09 client[8] disconnecting
2019/01/15 18:13:09 client[6] reports 0/337 packages still installed
2019/01/15 18:13:09 client[6] disconnecting
2019/01/15 18:13:09 client[3] reports 0/337 packages still installed
2019/01/15 18:13:09 client[3] disconnecting
2019/01/15 18:13:09 Step 2: Index all packages by brute-force
2019/01/15 18:13:09 Starting client[21]
2019/01/15 18:13:09 Starting client[13]
2019/01/15 18:13:09 Starting client[18]
2019/01/15 18:13:09 client[21] connecting to [localhost:8080]
2019/01/15 18:13:09 client[13] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[14]
2019/01/15 18:13:09 Starting client[19]
2019/01/15 18:13:09 Starting client[16]
2019/01/15 18:13:09 Starting client[20]
2019/01/15 18:13:09 client[14] connecting to [localhost:8080]
2019/01/15 18:13:09 client[19] connecting to [localhost:8080]
2019/01/15 18:13:09 client[16] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[12]
2019/01/15 18:13:09 client[20] connecting to [localhost:8080]
2019/01/15 18:13:09 client[12] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[17]
2019/01/15 18:13:09 client[17] connecting to [localhost:8080]
2019/01/15 18:13:09 Starting client[15]
2019/01/15 18:13:09 client[15] connecting to [localhost:8080]
2019/01/15 18:13:09 client[18] connecting to [localhost:8080]
2019/01/15 18:13:09 client[18] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[13] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[12] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[16] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[17] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[21] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[15] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[14] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[20] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[19] brute-forcing indexing of 337 packages
2019/01/15 18:13:09 client[21] reports 195/337 packages indexed
2019/01/15 18:13:09 client[15] reports 178/337 packages indexed
2019/01/15 18:13:09 client[18] reports 186/337 packages indexed
2019/01/15 18:13:09 client[20] reports 208/337 packages indexed
2019/01/15 18:13:09 client[16] reports 188/337 packages indexed
2019/01/15 18:13:09 client[19] reports 166/337 packages indexed
2019/01/15 18:13:09 client[12] reports 187/337 packages indexed
2019/01/15 18:13:09 client[13] reports 202/337 packages indexed
2019/01/15 18:13:09 client[14] reports 182/337 packages indexed
2019/01/15 18:13:09 client[17] reports 151/337 packages indexed
2019/01/15 18:13:09 client[15] reports 254/337 packages indexed
2019/01/15 18:13:09 client[19] reports 243/337 packages indexed
2019/01/15 18:13:09 client[20] reports 273/337 packages indexed
2019/01/15 18:13:09 client[13] reports 286/337 packages indexed
2019/01/15 18:13:09 client[12] reports 260/337 packages indexed
2019/01/15 18:13:09 client[21] reports 262/337 packages indexed
2019/01/15 18:13:09 client[16] reports 239/337 packages indexed
2019/01/15 18:13:09 client[18] reports 247/337 packages indexed
2019/01/15 18:13:09 client[14] reports 258/337 packages indexed
2019/01/15 18:13:09 client[17] reports 241/337 packages indexed
2019/01/15 18:13:10 client[15] reports 280/337 packages indexed
2019/01/15 18:13:10 client[19] reports 270/337 packages indexed
2019/01/15 18:13:10 client[13] reports 303/337 packages indexed
2019/01/15 18:13:10 client[20] reports 296/337 packages indexed
2019/01/15 18:13:10 client[12] reports 277/337 packages indexed
2019/01/15 18:13:10 client[18] reports 268/337 packages indexed
2019/01/15 18:13:10 client[21] reports 292/337 packages indexed
2019/01/15 18:13:10 client[16] reports 275/337 packages indexed
2019/01/15 18:13:10 client[14] reports 285/337 packages indexed
2019/01/15 18:13:10 client[17] reports 264/337 packages indexed
2019/01/15 18:13:10 client[15] reports 293/337 packages indexed
2019/01/15 18:13:10 client[19] reports 275/337 packages indexed
2019/01/15 18:13:10 client[13] reports 308/337 packages indexed
2019/01/15 18:13:10 client[20] reports 299/337 packages indexed
2019/01/15 18:13:10 client[21] reports 300/337 packages indexed
2019/01/15 18:13:10 client[12] reports 298/337 packages indexed
2019/01/15 18:13:10 client[18] reports 280/337 packages indexed
2019/01/15 18:13:10 client[16] reports 289/337 packages indexed
2019/01/15 18:13:10 client[14] reports 291/337 packages indexed
2019/01/15 18:13:10 client[17] reports 277/337 packages indexed
2019/01/15 18:13:10 client[19] reports 280/337 packages indexed
2019/01/15 18:13:10 client[15] reports 297/337 packages indexed
2019/01/15 18:13:10 client[13] reports 314/337 packages indexed
2019/01/15 18:13:10 client[20] reports 301/337 packages indexed
2019/01/15 18:13:10 client[21] reports 310/337 packages indexed
2019/01/15 18:13:10 client[18] reports 282/337 packages indexed
2019/01/15 18:13:10 client[12] reports 306/337 packages indexed
2019/01/15 18:13:10 client[14] reports 297/337 packages indexed
2019/01/15 18:13:10 client[16] reports 309/337 packages indexed
2019/01/15 18:13:10 client[17] reports 283/337 packages indexed
2019/01/15 18:13:10 client[19] reports 283/337 packages indexed
2019/01/15 18:13:10 client[15] reports 309/337 packages indexed
2019/01/15 18:13:10 client[13] reports 319/337 packages indexed
2019/01/15 18:13:10 client[21] reports 311/337 packages indexed
2019/01/15 18:13:10 client[14] reports 303/337 packages indexed
2019/01/15 18:13:10 client[20] reports 303/337 packages indexed
2019/01/15 18:13:10 client[18] reports 291/337 packages indexed
2019/01/15 18:13:10 client[12] reports 313/337 packages indexed
2019/01/15 18:13:10 client[16] reports 314/337 packages indexed
2019/01/15 18:13:10 client[17] reports 291/337 packages indexed
2019/01/15 18:13:11 client[19] reports 293/337 packages indexed
2019/01/15 18:13:11 client[15] reports 314/337 packages indexed
2019/01/15 18:13:11 client[13] reports 325/337 packages indexed
2019/01/15 18:13:11 client[14] reports 310/337 packages indexed
2019/01/15 18:13:11 client[21] reports 322/337 packages indexed
2019/01/15 18:13:11 client[20] reports 319/337 packages indexed
2019/01/15 18:13:11 client[16] reports 322/337 packages indexed
2019/01/15 18:13:11 client[12] reports 328/337 packages indexed
2019/01/15 18:13:11 client[18] reports 307/337 packages indexed
2019/01/15 18:13:11 client[17] reports 309/337 packages indexed
2019/01/15 18:13:11 client[19] reports 323/337 packages indexed
2019/01/15 18:13:11 client[15] reports 328/337 packages indexed
2019/01/15 18:13:11 client[13] reports 332/337 packages indexed
2019/01/15 18:13:11 client[14] reports 329/337 packages indexed
2019/01/15 18:13:11 client[20] reports 333/337 packages indexed
2019/01/15 18:13:11 client[21] reports 333/337 packages indexed
2019/01/15 18:13:11 client[16] reports 331/337 packages indexed
2019/01/15 18:13:11 client[18] reports 331/337 packages indexed
2019/01/15 18:13:11 client[12] reports 334/337 packages indexed
2019/01/15 18:13:11 client[17] reports 332/337 packages indexed
2019/01/15 18:13:11 client[19] reports 335/337 packages indexed
2019/01/15 18:13:11 client[15] reports 333/337 packages indexed
2019/01/15 18:13:11 client[13] reports 336/337 packages indexed
2019/01/15 18:13:11 client[14] reports 336/337 packages indexed
2019/01/15 18:13:11 client[20] reports 336/337 packages indexed
2019/01/15 18:13:11 client[21] reports 336/337 packages indexed
2019/01/15 18:13:11 client[12] reports 336/337 packages indexed
2019/01/15 18:13:11 client[18] reports 336/337 packages indexed
2019/01/15 18:13:11 client[16] reports 334/337 packages indexed
2019/01/15 18:13:11 client[17] reports 337/337 packages indexed
2019/01/15 18:13:11 client[17] disconnecting
2019/01/15 18:13:12 client[13] reports 337/337 packages indexed
2019/01/15 18:13:12 client[13] disconnecting
2019/01/15 18:13:12 client[15] reports 337/337 packages indexed
2019/01/15 18:13:12 client[15] disconnecting
2019/01/15 18:13:12 client[19] reports 337/337 packages indexed
2019/01/15 18:13:12 client[19] disconnecting
2019/01/15 18:13:12 client[14] reports 337/337 packages indexed
2019/01/15 18:13:12 client[14] disconnecting
2019/01/15 18:13:12 client[20] reports 337/337 packages indexed
2019/01/15 18:13:12 client[20] disconnecting
2019/01/15 18:13:12 client[12] reports 337/337 packages indexed
2019/01/15 18:13:12 client[12] disconnecting
2019/01/15 18:13:12 client[21] reports 337/337 packages indexed
2019/01/15 18:13:12 client[21] disconnecting
2019/01/15 18:13:12 client[18] reports 337/337 packages indexed
2019/01/15 18:13:12 client[18] disconnecting
2019/01/15 18:13:12 client[16] reports 337/337 packages indexed
2019/01/15 18:13:12 client[16] disconnecting
2019/01/15 18:13:12 Step 3: Verify if all packages were correctly indexed
2019/01/15 18:13:12 Starting client[31]
2019/01/15 18:13:12 Starting client[25]
2019/01/15 18:13:12 Starting client[23]
2019/01/15 18:13:12 Starting client[29]
2019/01/15 18:13:12 client[25] connecting to [localhost:8080]
2019/01/15 18:13:12 client[23] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[30]
2019/01/15 18:13:12 client[31] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[26]
2019/01/15 18:13:12 Starting client[28]
2019/01/15 18:13:12 client[28] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[27]
2019/01/15 18:13:12 Starting client[24]
2019/01/15 18:13:12 Starting client[22]
2019/01/15 18:13:12 client[24] connecting to [localhost:8080]
2019/01/15 18:13:12 client[22] connecting to [localhost:8080]
2019/01/15 18:13:12 client[29] connecting to [localhost:8080]
2019/01/15 18:13:12 client[30] connecting to [localhost:8080]
2019/01/15 18:13:12 client[26] connecting to [localhost:8080]
2019/01/15 18:13:12 client[27] connecting to [localhost:8080]
2019/01/15 18:13:12 client[24] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[29] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[25] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[31] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[23] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[27] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[28] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[30] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[26] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[22] querying for 337 packages and expecting status code to be [OK]
2019/01/15 18:13:12 client[22] disconnecting
2019/01/15 18:13:12 client[30] disconnecting
2019/01/15 18:13:12 client[28] disconnecting
2019/01/15 18:13:12 client[25] disconnecting
2019/01/15 18:13:12 client[26] disconnecting
2019/01/15 18:13:12 client[29] disconnecting
2019/01/15 18:13:12 client[24] disconnecting
2019/01/15 18:13:12 client[31] disconnecting
2019/01/15 18:13:12 client[27] disconnecting
2019/01/15 18:13:12 client[23] disconnecting
2019/01/15 18:13:12 Step 4: Remove all installed packages
2019/01/15 18:13:12 Starting client[41]
2019/01/15 18:13:12 Starting client[35]
2019/01/15 18:13:12 Starting client[32]
2019/01/15 18:13:12 Starting client[38]
2019/01/15 18:13:12 client[41] connecting to [localhost:8080]
2019/01/15 18:13:12 client[35] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[36]
2019/01/15 18:13:12 client[38] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[34]
2019/01/15 18:13:12 client[36] connecting to [localhost:8080]
2019/01/15 18:13:12 client[34] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[40]
2019/01/15 18:13:12 client[32] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[37]
2019/01/15 18:13:12 Starting client[39]
2019/01/15 18:13:12 client[40] connecting to [localhost:8080]
2019/01/15 18:13:12 Starting client[33]
2019/01/15 18:13:12 client[39] connecting to [localhost:8080]
2019/01/15 18:13:12 client[37] connecting to [localhost:8080]
2019/01/15 18:13:12 client[33] connecting to [localhost:8080]
2019/01/15 18:13:12 client[35] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[33] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[40] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[36] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[38] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[34] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[41] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[37] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[39] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[32] brute-forcing removal of 337 packages
2019/01/15 18:13:12 client[40] reports 8/337 packages still installed
2019/01/15 18:13:12 client[41] reports 6/337 packages still installed
2019/01/15 18:13:12 client[39] reports 10/337 packages still installed
2019/01/15 18:13:12 client[36] reports 40/337 packages still installed
2019/01/15 18:13:12 client[35] reports 48/337 packages still installed
2019/01/15 18:13:12 client[38] reports 20/337 packages still installed
2019/01/15 18:13:12 client[34] reports 72/337 packages still installed
2019/01/15 18:13:12 client[32] reports 168/337 packages still installed
2019/01/15 18:13:12 client[37] reports 40/337 packages still installed
2019/01/15 18:13:12 client[33] reports 110/337 packages still installed
2019/01/15 18:13:12 client[41] reports 0/337 packages still installed
2019/01/15 18:13:12 client[38] reports 1/337 packages still installed
2019/01/15 18:13:12 client[41] disconnecting
2019/01/15 18:13:12 client[39] reports 0/337 packages still installed
2019/01/15 18:13:12 client[39] disconnecting
2019/01/15 18:13:12 client[40] reports 1/337 packages still installed
2019/01/15 18:13:12 client[36] reports 6/337 packages still installed
2019/01/15 18:13:12 client[35] reports 15/337 packages still installed
2019/01/15 18:13:12 client[33] reports 51/337 packages still installed
2019/01/15 18:13:12 client[34] reports 19/337 packages still installed
2019/01/15 18:13:12 client[37] reports 9/337 packages still installed
2019/01/15 18:13:12 client[32] reports 125/337 packages still installed
2019/01/15 18:13:12 client[38] reports 0/337 packages still installed
2019/01/15 18:13:12 client[38] disconnecting
2019/01/15 18:13:12 client[40] reports 0/337 packages still installed
2019/01/15 18:13:12 client[40] disconnecting
2019/01/15 18:13:12 client[36] reports 1/337 packages still installed
2019/01/15 18:13:12 client[35] reports 4/337 packages still installed
2019/01/15 18:13:12 client[34] reports 2/337 packages still installed
2019/01/15 18:13:12 client[37] reports 2/337 packages still installed
2019/01/15 18:13:12 client[33] reports 22/337 packages still installed
2019/01/15 18:13:12 client[32] reports 87/337 packages still installed
2019/01/15 18:13:12 client[35] reports 0/337 packages still installed
2019/01/15 18:13:12 client[35] disconnecting
2019/01/15 18:13:12 client[36] reports 0/337 packages still installed
2019/01/15 18:13:12 client[36] disconnecting
2019/01/15 18:13:12 client[34] reports 0/337 packages still installed
2019/01/15 18:13:12 client[34] disconnecting
2019/01/15 18:13:12 client[33] reports 6/337 packages still installed
2019/01/15 18:13:12 client[37] reports 1/337 packages still installed
2019/01/15 18:13:12 client[32] reports 61/337 packages still installed
2019/01/15 18:13:12 client[33] reports 1/337 packages still installed
2019/01/15 18:13:12 client[37] reports 0/337 packages still installed
2019/01/15 18:13:12 client[37] disconnecting
2019/01/15 18:13:12 client[32] reports 49/337 packages still installed
2019/01/15 18:13:12 client[33] reports 1/337 packages still installed
2019/01/15 18:13:12 client[32] reports 41/337 packages still installed
2019/01/15 18:13:12 client[33] reports 1/337 packages still installed
2019/01/15 18:13:12 client[32] reports 34/337 packages still installed
2019/01/15 18:13:13 client[33] reports 1/337 packages still installed
2019/01/15 18:13:13 client[32] reports 27/337 packages still installed
2019/01/15 18:13:13 client[33] reports 1/337 packages still installed
2019/01/15 18:13:13 client[32] reports 20/337 packages still installed
2019/01/15 18:13:13 client[33] reports 1/337 packages still installed
2019/01/15 18:13:13 client[32] reports 16/337 packages still installed
2019/01/15 18:13:13 client[33] reports 1/337 packages still installed
2019/01/15 18:13:13 client[32] reports 12/337 packages still installed
2019/01/15 18:13:13 client[33] reports 0/337 packages still installed
2019/01/15 18:13:13 client[33] disconnecting
2019/01/15 18:13:13 client[32] reports 5/337 packages still installed
2019/01/15 18:13:13 client[32] reports 2/337 packages still installed
2019/01/15 18:13:13 client[32] reports 0/337 packages still installed
2019/01/15 18:13:13 client[32] disconnecting
2019/01/15 18:13:13 Step 5: Verify if all packages were correctly removed
2019/01/15 18:13:13 Starting client[42]
2019/01/15 18:13:13 Starting client[48]
2019/01/15 18:13:13 Starting client[47]
2019/01/15 18:13:13 Starting client[49]
2019/01/15 18:13:13 client[47] connecting to [localhost:8080]
2019/01/15 18:13:13 client[48] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[45]
2019/01/15 18:13:13 client[49] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[46]
2019/01/15 18:13:13 client[45] connecting to [localhost:8080]
2019/01/15 18:13:13 client[46] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[44]
2019/01/15 18:13:13 client[44] connecting to [localhost:8080]
2019/01/15 18:13:13 client[42] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[50]
2019/01/15 18:13:13 client[50] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[51]
2019/01/15 18:13:13 client[51] connecting to [localhost:8080]
2019/01/15 18:13:13 Starting client[43]
2019/01/15 18:13:13 client[43] connecting to [localhost:8080]
2019/01/15 18:13:13 client[43] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[51] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[50] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[44] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[49] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[47] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[45] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[46] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[48] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[42] querying for 337 packages and expecting status code to be [FAIL]
2019/01/15 18:13:13 client[49] disconnecting
2019/01/15 18:13:13 client[48] disconnecting
2019/01/15 18:13:13 client[47] disconnecting
2019/01/15 18:13:13 client[45] disconnecting
2019/01/15 18:13:13 client[51] disconnecting
2019/01/15 18:13:13 client[50] disconnecting
2019/01/15 18:13:13 client[42] disconnecting
2019/01/15 18:13:13 client[46] disconnecting
2019/01/15 18:13:13 client[44] disconnecting
2019/01/15 18:13:13 client[43] disconnecting
2019/01/15 18:13:13 TESTRUN - FINISHED (took 4448ms 4.448232039s)
2019/01/15 18:13:13 ================
2019/01/15 18:13:13 All tests passed!
2019/01/15 18:13:13 ================
2019/01/15 18:13:13 TESTRUN finished! (took 4448ms)
mve@box package_contents $


2019/01/16 02:13:13.663057 serve.go:46: serving 127.0.0.1:52956: "QUERY|duti|"
2019/01/16 02:13:13.663074 serve.go:52: done 127.0.0.1:52956:"QUERY|duti|" -> "FAIL"
2019/01/16 02:13:13.663095 serve.go:46: serving 127.0.0.1:52947: "QUERY|cifer|"
2019/01/16 02:13:13.663108 serve.go:52: done 127.0.0.1:52947:"QUERY|cifer|" -> "FAIL"
2019/01/16 02:13:13.663129 serve.go:46: serving 127.0.0.1:52956: "QUERY|dvd+rw-tools|"
2019/01/16 02:13:13.663142 serve.go:52: done 127.0.0.1:52956:"QUERY|dvd+rw-tools|" -> "FAIL"
2019/01/16 02:13:13.663156 serve.go:46: serving 127.0.0.1:52947: "QUERY|cig|"
2019/01/16 02:13:13.663168 serve.go:52: done 127.0.0.1:52947:"QUERY|cig|" -> "FAIL"
2019/01/16 02:13:13.663187 serve.go:46: serving 127.0.0.1:52956: "QUERY|dvdauthor|"
2019/01/16 02:13:13.663200 serve.go:52: done 127.0.0.1:52956:"QUERY|dvdauthor|" -> "FAIL"
2019/01/16 02:13:13.663227 serve.go:46: serving 127.0.0.1:52947: "QUERY|godep|"
2019/01/16 02:13:13.663249 serve.go:52: done 127.0.0.1:52947:"QUERY|godep|" -> "FAIL"
2019/01/16 02:13:13.663263 serve.go:46: serving 127.0.0.1:52956: "QUERY|libdvdcss|"
2019/01/16 02:13:13.663271 serve.go:52: done 127.0.0.1:52956:"QUERY|libdvdcss|" -> "FAIL"
2019/01/16 02:13:13.663306 serve.go:46: serving 127.0.0.1:52947: "QUERY|cimg|"
2019/01/16 02:13:13.663318 serve.go:52: done 127.0.0.1:52947:"QUERY|cimg|" -> "FAIL"
2019/01/16 02:13:13.663333 serve.go:29: 127.0.0.1:52956 client closed connection
2019/01/16 02:13:13.663379 serve.go:46: serving 127.0.0.1:52947: "QUERY|cityhash|"
2019/01/16 02:13:13.663389 serve.go:52: done 127.0.0.1:52947:"QUERY|cityhash|" -> "FAIL"
2019/01/16 02:13:13.663440 serve.go:29: 127.0.0.1:52947 client closed connection
^C2019/01/16 02:13:48.575148 listen.go:59: Signaling to stop accepting connections
2019/01/16 02:13:48.576283 listen.go:23: Waiting for connections to close
2019/01/16 02:13:48.576319 listen.go:67: Waiting to stop accepting connections
2019/01/16 02:13:48.576322 serve.go:25: 127.0.0.1:53000 dropping client connection
2019/01/16 02:13:48.576355 listen.go:73: Shutting down Scoop server
2019/01/16 02:13:48.576376 listen.go:78: Saving datafile
2019/01/16 02:13:48.576548 store.go:176: unloading "./scoop-data/scoop.json" datafile
mve@box scoop (day2) $
```